### PR TITLE
Small modif done in Theano version.

### DIFF
--- a/include/cnmem.h
+++ b/include/cnmem.h
@@ -249,7 +249,7 @@ cnmemStatus_t CNMEM_API cnmemPrintMemoryState(FILE *file, cudaStream_t stream);
 /**
  * \brief Converts a cnmemStatus_t value to a string.
  */
-const char* cnmemGetErrorString(cnmemStatus_t status);
+const char* CNMEM_API cnmemGetErrorString(cnmemStatus_t status);
 
 /* ********************************************************************************************* */
 

--- a/include/cnmem.h
+++ b/include/cnmem.h
@@ -41,7 +41,11 @@
 #define CNMEM_API __declspec(dllimport)
 #endif
 #else
+#ifdef CNMEM_DLLEXPORT
+#define CNMEM_API __attribute__((visibility ("default")))
+#else
 #define CNMEM_API
+#endif
 #endif
 
 #define CNMEM_VERSION 100 // It corresponds to 1.0.0

--- a/src/cnmem.cpp
+++ b/src/cnmem.cpp
@@ -186,7 +186,7 @@ static inline std::size_t ceilInt(std::size_t m, std::size_t n) {
 
 class Mutex {
 #ifdef WIN32
-    CRITICAL_SECTION mCriticalSection;
+    mutable CRITICAL_SECTION mCriticalSection;
 #else
     pthread_mutex_t  mMutex;
 #endif


### PR DESCRIPTION
This allow Theano to continue to use hidden symbol by default.

This is needed to work around strange default on Mac.
