### PR TITLE
fixed base address misalignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,12 @@ if(WITH_TESTS)
   endif(CMAKE_COMPILER_IS_GNUCC)
   target_link_libraries(cnmem_tests LINK_PUBLIC cnmem ${CUDA_LIBRARIES} ${GTEST_LIBRARIES} -lpthread)
   install(TARGETS cnmem_tests RUNTIME DESTINATION bin)
-  
+
+  # Tests that launch kernels to force reading and writing to memory
+  cuda_add_executable(cnmem_kernel_tests tests/cnmem_kernel_test.cu)
+  target_link_libraries(cnmem_kernel_tests cnmem ${CUDA_LIBRARIES} ${GTEST_LIBRARIES} -lpthread)
+  install(TARGETS cnmem_kernel_tests RUNTIME DESTINATION bin)
+
   # On Windows, we copy the Google test DLL to the bin folder.
   if(MSVC)
     get_filename_component(gtest_dll_path ${GTEST_LIBRARIES} DIRECTORY)

--- a/src/cnmem.cpp
+++ b/src/cnmem.cpp
@@ -1110,6 +1110,9 @@ cnmemStatus_t cnmemInit(int numDevices, const cnmemDevice_t *devices, unsigned f
             child->setStream(devices[i].streams[j]);
             child->setFlags(flags & ~CNMEM_FLAGS_CANNOT_GROW);
             if( devices[i].streamSizes && devices[i].streamSizes[j] > 0 ) {
+                //https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#sequential-but-misaligned-access-pattern
+                //Align stream blocks so stream base addresses are alligned to CNMEM_GRANULARITY
+                devices[i].streamSizes[j] = cnmem::ceilInt(devices[i].streamSizes[j], CNMEM_GRANULARITY);
                 CNMEM_CHECK(child->reserve(devices[i].streamSizes[j]));
             }
             CNMEM_CHECK(manager.addChild(child));

--- a/tests/cnmem_kernel_test.cu
+++ b/tests/cnmem_kernel_test.cu
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+#include <cnmem.h>
+#include <stdint.h>
+#include <fstream>
+
+static std::size_t getFreeMemory() {
+    cudaFree(0);
+    std::size_t freeMem, totalMem;
+    cudaMemGetInfo(&freeMem, &totalMem);
+    return freeMem;
+}
+
+class CnmemTest : public ::testing::Test {
+    /// We determine the amount of free memory.
+    std::size_t mFreeMem;
+    
+protected:
+    /// Do we test memory leaks.
+    bool mTestLeaks;
+    /// Do we skip finalization.
+    bool mFinalize;
+    
+public:
+    /// Ctor.
+    CnmemTest() : mFreeMem(getFreeMemory()), mTestLeaks(true), mFinalize(true) {}
+    /// Tear down the test.
+    void TearDown();
+};
+
+void CnmemTest::TearDown() {
+    if( mFinalize ) {
+        ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemFinalize()); 
+    }
+    if( mTestLeaks ) {
+        ASSERT_EQ(mFreeMem, getFreeMemory());
+    }
+    cudaDeviceReset();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+__global__ void tinyKernel(T* d_a, int numElem)
+{
+    int ind = (blockIdx.x * blockDim.x) + threadIdx.x;
+    if(ind >= numElem)
+        return;
+    d_a[ind] += 1;
+}
+
+
+struct _24ByteStruct
+{
+    double a;
+    double c;
+    double b;
+
+    __host__ __device__
+    void operator +=(int other)
+    {
+        a += other;
+        b += other;
+        c += other;
+    }
+
+    __host__ __device__
+    void operator =(int other)
+    {
+        a = other;
+        b = other;
+        c = other;
+    }
+};
+
+template<typename T, int expectedSize>
+void testAlign()
+{
+    const int numElem = 200;
+    const int size = numElem*sizeof(T);
+    T* cpuData = new T[numElem];
+    for(int i = 0; i < numElem; i++)
+        cpuData[i] = i;
+
+    ASSERT_EQ(expectedSize, sizeof(T));
+
+    cudaStream_t streams[2];
+    ASSERT_EQ(cudaSuccess, cudaStreamCreate(&streams[0]));
+    ASSERT_EQ(cudaSuccess, cudaStreamCreate(&streams[1]));
+
+    cnmemDevice_t device;
+    memset(&device, 0, sizeof(device));
+    device.numStreams = 2;
+    device.streams = streams;
+    //intentonally misallign, but could be from calculation based on gpu size
+    size_t streamSizes[] = { size*2 + sizeof(T) - 1, size*2 + sizeof(T) - 1 };
+    device.streamSizes = streamSizes;
+
+    ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemInit(1, &device, CNMEM_FLAGS_DEFAULT));
+    T *ptr0, *ptr1;
+    ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemMalloc((void**)&ptr0, size, streams[0]));
+    ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemMalloc((void**)&ptr1, size, streams[1]));
+
+    ASSERT_EQ(cudaSuccess, cudaMemcpyAsync(ptr0, cpuData, size, cudaMemcpyHostToDevice, streams[0]));
+    ASSERT_EQ(cudaSuccess, cudaMemcpyAsync(ptr1, cpuData, size, cudaMemcpyHostToDevice, streams[1]));
+
+    //force read and write from ptr0,1
+    tinyKernel<<<numElem, 1, 0, streams[0]>>>(ptr0, numElem);
+    tinyKernel<<<numElem, 1, 0, streams[1]>>>(ptr1, numElem);
+
+    ASSERT_EQ(cudaSuccess, cudaStreamSynchronize(streams[0]));
+    ASSERT_EQ(cudaSuccess, cudaStreamSynchronize(streams[1]));
+
+    ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemFree(ptr1, streams[1])); 
+    ASSERT_EQ(CNMEM_STATUS_SUCCESS, cnmemFree(ptr0, streams[0]));
+    
+    ASSERT_EQ(cudaSuccess, cudaStreamDestroy(streams[0]));
+    ASSERT_EQ(cudaSuccess, cudaStreamDestroy(streams[1]));
+
+    ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+}
+
+TEST_F(CnmemTest, alignment8) {
+    testAlign<char, 1>();
+}
+
+TEST_F(CnmemTest, alignment16) {
+    testAlign<short, 2>();
+}
+
+TEST_F(CnmemTest, alignment32) {
+    testAlign<float, 4>();
+}
+
+TEST_F(CnmemTest, alignment64) {
+    testAlign<double, 8>();
+}
+
+TEST_F(CnmemTest, alignment192) {
+    testAlign<_24ByteStruct, 24>();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+


### PR DESCRIPTION
The offset for each allocated block allocated within a stream is aligned by `CNMEM_GRANULARITY`, but the base address for each stream might not be. This misalignment can cause an error when trying to write to an address not a multiple of wrap size. Described in the [documentation here](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#sequential-but-misaligned-access-pattern):

> Consider what would happen to the memory addresses accessed by the second, third, and subsequent thread blocks if the thread block size was not a multiple of warp size.

See the [new tests](https://github.com/NVIDIA/cnmem/compare/master...mattangus:master#diff-c511eb6835107abbc40b2b90b1671662) added for examples of where this causes problems. The error code generated is 74 "misaligned address".

A thanks to @mElBalkini for helping find a solution to this bug.