### PR TITLE
ENH Added option (and tests) to use cudaMallocManaged for the allocator.

### DIFF
--- a/include/cnmem.h
+++ b/include/cnmem.h
@@ -73,6 +73,7 @@ typedef enum
   CNMEM_FLAGS_DEFAULT = 0,       /// Default flags.
   CNMEM_FLAGS_CANNOT_GROW = 1,   /// Prevent the manager from growing its memory consumption.
   CNMEM_FLAGS_CANNOT_STEAL = 2,  /// Prevent the manager from stealing memory.
+  CNMEM_FLAGS_MANAGED = 4,       /// Use cudaMallocManaged for the allocator.
 } cnmemManagerFlags_t;
 
 /* ********************************************************************************************* */

--- a/src/cnmem.cpp
+++ b/src/cnmem.cpp
@@ -508,8 +508,15 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         CNMEM_CHECK(mParent->allocate(data, size, mIsStreamBlocking));
     }
     else {
-        CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);
-        CNMEM_CHECK_CUDA(cudaMalloc(&data, size));
+        if (mFlags & CNMEM_FLAGS_MANAGED) {
+            CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
+            CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
+            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice));
+        }
+        else {
+            CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);
+            CNMEM_CHECK_CUDA(cudaMalloc(&data, size));
+        }
         CNMEM_DEBUG_INFO(">> returned address=0x%016lx\n", (size_t) data);
     }
     


### PR DESCRIPTION
I added an option, `CNMEM_FLAGS_MANAGED`. If set, CNMem uses `cudaMallocManaged()` for allocating device memory.  It prefetches all memory to the GPU using `cudaMemPrefetchAsync()`. Thus, it behaves just like `cudaMalloc` if only GPU code touches the memory. 

@nsakharnykh tested this behavior and found that for cuDF it resulted in no performance cost. Moreover, it means that if other CUDA code allocates device memory with `cudaMalloc`, pages from the cnmem can be evicted to make room. This makes libraries that use cnmem more friendly to libraries in the same app that do not, resulting in fewer out of memory errors.

I also modified the tests to run all tests with both default and managed allocation and all tests pass.